### PR TITLE
Fixed google photos links

### DIFF
--- a/meetups/hyderabad/01-assemble/README.md
+++ b/meetups/hyderabad/01-assemble/README.md
@@ -31,4 +31,4 @@ organizers:
 
 <EventPage />
 ## Google Photos Album 
-[https://photos.app.goo.gl/BU6QXzECrQBTG2dB9](https://photos.app.goo.gl/BU6QXzECrQBTG2dB9)
+https://photos.app.goo.gl/BU6QXzECrQBTG2dB9

--- a/meetups/hyderabad/02-jingle-bells/README.md
+++ b/meetups/hyderabad/02-jingle-bells/README.md
@@ -40,5 +40,6 @@ organizers:
 ---
 
 <EventPage />
-## Google Photos Album 
-[https://photos.app.goo.gl/BU6QXzECrQBTG2dB9](https://photos.app.goo.gl/BU6QXzECrQBTG2dB9)
+## Google Photos Album
+https://photos.app.goo.gl/BU6QXzECrQBTG2dB9
+


### PR DESCRIPTION
The Google photos link upon clicking opens wrong link  (due to markdown syntax, I'm assuming)